### PR TITLE
Add pex build

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -91,3 +91,48 @@ jobs:
           # source .venv/bin/activate
           # pytest tests/
           # coverage report
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+      #----------------------------------------------
+      #        load pip cache if cache exists
+      #----------------------------------------------
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip
+          restore-keys: ${{ runner.os }}-pip
+      #----------------------------------------------
+      #          Create pex build
+      #----------------------------------------------
+      - run: python -m pip install pex poetry
+      - run: |
+          echo "Cleaning up"
+          rm -rf dist/install_multikas
+          rm -rf ~/.pex/
+          rm -rf .venv/
+
+          echo "poetry install --only main"
+          poetry install --only main
+
+          echo "poetry export -f requirements.txt --without-hashes --output requirements.txt"
+          poetry export -f requirements.txt --without-hashes --output requirements.txt
+
+          echo "poetry run pex . --requirement=requirements.txt --python-shebang='#!/usr/bin/env python3' -o dist/mooseapi_server -e \"mooseapi.main\""
+          poetry run pex . --requirement=requirements.txt --python-shebang='#!/usr/bin/env python3' -o dist/mooseapi_server -e "mooseapi.main"
+
+          echo "chmod +x dist/mooseapi_server"
+          chmod +x dist/mooseapi_server
+
+      # Reference: https://github.com/actions/upload-artifact
+      - name: Archive Build Artifacts from CI Pipeline
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            dist/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# To use:
+#
+#     pre-commit run -a
+#
+# Or:
+#
+#     pre-commit install  # (runs every time you commit in git)
+#
+# To update this file:
+#
+#     pre-commit autoupdate
+#
+# See https://github.com/pre-commit/pre-commit
+#
+# Based on:
+# https://github.com/mpnunez/pybind11-conan-example/blob/a259bfe9bd99ded80f4bf16ce7c639e140f26408/.pre-commit-config.yaml
+repos:
+# Standard hooks
+# - repo: https://github.com/pre-commit/pre-commit-hooks
+#   rev: v3.2.0
+#   hooks:
+#   - id: check-yaml
+#   - id: end-of-file-fixer
+#   - id: mixed-line-ending
+#   - id: trailing-whitespace
+#   - id: fix-encoding-pragma
+
+# Black, the code formatter, natively supports pre-commit
+- repo: https://github.com/psf/black
+  rev: 23.1.0
+  hooks:
+  - id: black
+    exclude: ^.github/$
+

--- a/mooseapi/main.py
+++ b/mooseapi/main.py
@@ -1,5 +1,6 @@
 from fastapi import Depends, FastAPI, Form, UploadFile, Body
 from fastapi.params import File
+import uvicorn
 
 from mooseapi.image_processing import decode_image
 from mooseapi.models import ArticleModel, FileModel, ImageModel, ImageType
@@ -114,3 +115,7 @@ def post_arbitrary_body(payload: JSONStructure = None):
     print(f"Deserialized JSON values")
     print(des_values)
     return {"keys": des_keys, "values": des_values}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
Add pex build.

This doesn't work, likely because `fastapi` depends on `uvloop`, which has native dependencies.

The result, running the pex is: 
```
./mooseapi_server 
Failed to find compatible interpreter on path /Users/b-long/.pyenv/versions/3.9.16/bin:/usr/local/Cellar/pyenv/2.3.16/libexec:/usr/local/Cellar/pyenv/2.3.16/plugins/python-build/bin:/Users/b-long/.pyenv/shims:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/b-long/.local/bin.

Examined the following interpreters:
1.)                                                   /Users/b-long/.pyenv/versions/3.9.16/bin/python3.9 CPython==3.9.16
2.)     /usr/local/Cellar/python@3.11/3.11.2_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11 CPython==3.11.2
3.) /Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/bin/python3.9 CPython==3.9.6

No interpreter compatible with the requested constraints was found:

  Failed to resolve requirements from PEX environment @ /Users/b-long/.pex/unzipped_pexes/f209ff55df12bb4b128c0dd4bf8030b6f3ee6dc9.
  Needed cp39-cp39-macosx_12_0_x86_64 compatible dependencies for:
   1: pydantic!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0,>=1.6.2
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='pydantic', normalized='pydantic') distributions.
   2: MarkupSafe>=2.0
      Required by:
        Jinja2 3.1.2
      But this pex had no ProjectName(raw='MarkupSafe', normalized='markupsafe') distributions.
   3: orjson>=3.2.1; extra == "all"
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='orjson', normalized='orjson') distributions.
   4: pyyaml>=5.3.1; extra == "all"
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='pyyaml', normalized='pyyaml') distributions.
   5: ujson!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0,>=4.0.1; extra == "all"
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='ujson', normalized='ujson') distributions.
   6: httptools>=0.5.0; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='httptools', normalized='httptools') distributions.
   7: pyyaml>=5.1; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='pyyaml', normalized='pyyaml') distributions.
   8: uvloop!=0.15.0,!=0.15.1,>=0.14.0; sys_platform != "win32" and (sys_platform != "cygwin" and platform_python_implementation != "PyPy") and extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='uvloop', normalized='uvloop') distributions.
   9: watchfiles>=0.13; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='watchfiles', normalized='watchfiles') distributions.
   10: websockets>=10.4; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='websockets', normalized='websockets') distributions.
   11: httptools==0.5.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='httptools', normalized='httptools') distributions.
   12: markupsafe==2.1.2; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='markupsafe', normalized='markupsafe') distributions.
   13: Pillow<10.0.0,>=9.2.0
      Required by:
        mooseapi 0.1.0
      But this pex had no ProjectName(raw='Pillow', normalized='pillow') distributions.
   14: orjson==3.8.7; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='orjson', normalized='orjson') distributions.
   15: pillow==9.4.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='pillow', normalized='pillow') distributions.
   16: pydantic==1.10.6; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='pydantic', normalized='pydantic') distributions.
   17: pyyaml==6.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='pyyaml', normalized='pyyaml') distributions.
   18: ujson==5.7.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='ujson', normalized='ujson') distributions.
   19: uvloop==0.17.0; sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy" and python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='uvloop', normalized='uvloop') distributions.
   20: watchfiles==0.18.1; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='watchfiles', normalized='watchfiles') distributions.
   21: websockets==10.4; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='websockets', normalized='websockets') distributions.

  Failed to resolve requirements from PEX environment @ /Users/b-long/.pex/unzipped_pexes/f209ff55df12bb4b128c0dd4bf8030b6f3ee6dc9.
  Needed cp311-cp311-macosx_12_0_x86_64 compatible dependencies for:
   1: pydantic!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0,>=1.6.2
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='pydantic', normalized='pydantic') distributions.
   2: MarkupSafe>=2.0
      Required by:
        Jinja2 3.1.2
      But this pex had no ProjectName(raw='MarkupSafe', normalized='markupsafe') distributions.
   3: orjson>=3.2.1; extra == "all"
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='orjson', normalized='orjson') distributions.
   4: pyyaml>=5.3.1; extra == "all"
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='pyyaml', normalized='pyyaml') distributions.
   5: ujson!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0,>=4.0.1; extra == "all"
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='ujson', normalized='ujson') distributions.
   6: httptools>=0.5.0; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='httptools', normalized='httptools') distributions.
   7: pyyaml>=5.1; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='pyyaml', normalized='pyyaml') distributions.
   8: uvloop!=0.15.0,!=0.15.1,>=0.14.0; sys_platform != "win32" and (sys_platform != "cygwin" and platform_python_implementation != "PyPy") and extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='uvloop', normalized='uvloop') distributions.
   9: watchfiles>=0.13; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='watchfiles', normalized='watchfiles') distributions.
   10: websockets>=10.4; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='websockets', normalized='websockets') distributions.
   11: httptools==0.5.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='httptools', normalized='httptools') distributions.
   12: markupsafe==2.1.2; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='markupsafe', normalized='markupsafe') distributions.
   13: Pillow<10.0.0,>=9.2.0
      Required by:
        mooseapi 0.1.0
      But this pex had no ProjectName(raw='Pillow', normalized='pillow') distributions.
   14: orjson==3.8.7; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='orjson', normalized='orjson') distributions.
   15: pillow==9.4.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='pillow', normalized='pillow') distributions.
   16: pydantic==1.10.6; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='pydantic', normalized='pydantic') distributions.
   17: pyyaml==6.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='pyyaml', normalized='pyyaml') distributions.
   18: ujson==5.7.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='ujson', normalized='ujson') distributions.
   19: uvloop==0.17.0; sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy" and python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='uvloop', normalized='uvloop') distributions.
   20: watchfiles==0.18.1; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='watchfiles', normalized='watchfiles') distributions.
   21: websockets==10.4; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='websockets', normalized='websockets') distributions.

  Failed to resolve requirements from PEX environment @ /Users/b-long/.pex/unzipped_pexes/f209ff55df12bb4b128c0dd4bf8030b6f3ee6dc9.
  Needed cp39-cp39-macosx_12_0_x86_64 compatible dependencies for:
   1: pydantic!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0,>=1.6.2
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='pydantic', normalized='pydantic') distributions.
   2: MarkupSafe>=2.0
      Required by:
        Jinja2 3.1.2
      But this pex had no ProjectName(raw='MarkupSafe', normalized='markupsafe') distributions.
   3: orjson>=3.2.1; extra == "all"
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='orjson', normalized='orjson') distributions.
   4: pyyaml>=5.3.1; extra == "all"
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='pyyaml', normalized='pyyaml') distributions.
   5: ujson!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0,>=4.0.1; extra == "all"
      Required by:
        fastapi 0.94.1
      But this pex had no ProjectName(raw='ujson', normalized='ujson') distributions.
   6: httptools>=0.5.0; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='httptools', normalized='httptools') distributions.
   7: pyyaml>=5.1; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='pyyaml', normalized='pyyaml') distributions.
   8: uvloop!=0.15.0,!=0.15.1,>=0.14.0; sys_platform != "win32" and (sys_platform != "cygwin" and platform_python_implementation != "PyPy") and extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='uvloop', normalized='uvloop') distributions.
   9: watchfiles>=0.13; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='watchfiles', normalized='watchfiles') distributions.
   10: websockets>=10.4; extra == "standard"
      Required by:
        uvicorn 0.21.1
      But this pex had no ProjectName(raw='websockets', normalized='websockets') distributions.
   11: httptools==0.5.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='httptools', normalized='httptools') distributions.
   12: markupsafe==2.1.2; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='markupsafe', normalized='markupsafe') distributions.
   13: Pillow<10.0.0,>=9.2.0
      Required by:
        mooseapi 0.1.0
      But this pex had no ProjectName(raw='Pillow', normalized='pillow') distributions.
   14: orjson==3.8.7; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='orjson', normalized='orjson') distributions.
   15: pillow==9.4.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='pillow', normalized='pillow') distributions.
   16: pydantic==1.10.6; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='pydantic', normalized='pydantic') distributions.
   17: pyyaml==6.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='pyyaml', normalized='pyyaml') distributions.
   18: ujson==5.7.0; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='ujson', normalized='ujson') distributions.
   19: uvloop==0.17.0; sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy" and python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='uvloop', normalized='uvloop') distributions.
   20: watchfiles==0.18.1; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='watchfiles', normalized='watchfiles') distributions.
   21: websockets==10.4; python_version >= "3.9" and python_version < "4.0"
      But this pex had no ProjectName(raw='websockets', normalized='websockets') distributions.
```